### PR TITLE
feat: Member, Together 도메인 엔티티 및 관계 설정 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the backend API server for the CultureMate platform - a Spring Boot application using Java 21 with JPA/Hibernate, H2 database, and Lombok for boilerplate reduction.
+
+## Core Commands
+
+### Development
+- `./gradlew bootRun` - Start the Spring Boot application
+- `./gradlew build` - Build the project
+- `./gradlew clean` - Clean build artifacts
+- `./gradlew test` - Run all tests
+- `./gradlew test --tests ClassName` - Run specific test class
+- `./gradlew test --tests ClassName.testMethodName` - Run specific test method
+
+### Database
+- H2 Console: Access at `http://localhost:8080/h2-console` when running
+- JDBC URL: `jdbc:h2:tcp://localhost/~/CULTURE-MATE/culture-mate-BACK/testDB`
+- Username: `sa` (no password)
+
+## Architecture
+
+### Package Structure
+- `com.culturemate.culturemate_api` - Root package
+- `domain/` - JPA entities (Member, Together, Role enum)
+- `repository/` - Data access layer (currently empty, likely for Spring Data JPA repositories)
+
+### Domain Model
+- **Member**: User entity with login_id, password, role (ADMIN/MEMBER), and joined_at timestamp
+- **Together**: Entity representing group activities with host relationship to Member
+- **Role**: Enum with ADMIN and MEMBER values
+
+### Technology Stack
+- **Framework**: Spring Boot 3.5.5
+- **Java**: Version 21
+- **Database**: H2 (in-memory/file-based)
+- **ORM**: Spring Data JPA with Hibernate
+- **Template Engine**: Thymeleaf
+- **Build Tool**: Gradle with wrapper
+- **Development**: Spring Boot DevTools for hot reload
+- **Code Generation**: Lombok for getters/setters
+
+### Configuration Notes
+- H2 database configured with `ddl-auto: create` (recreates schema on startup)
+- SQL logging enabled for debugging
+- Application name: "CultureMate API"
+- Uses TCP connection to H2 database file
+
+## Coding Conventions
+- **Indentation**: 2 spaces (no tabs)
+- **Entity naming**: PascalCase (e.g., Member, Together, Participants)
+- **Variable naming**: camelCase
+- **File naming**: PascalCase for classes, camelCase for other files
+
+## Git Workflow
+### Commit Message Convention
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+- `feat`: 새로운 기능
+- `fix`: 버그 수정  
+- `docs`: 문서 변경
+- `style`: 코드 포맷팅 (기능 변경 없음)
+- `refactor`: 코드 리팩토링
+- `test`: 테스트 추가/수정
+- `chore`: 빌드 프로세스, 도구 설정 등
+
+**Examples:**
+```
+feat: 네비게이션바 생성
+
+feat!: 사용자 등록 API 추가
+
+유저 회원가입 기능을 추가했습니다.
+- 이메일/비밀번호 입력받아 저장  
+- 중복 이메일 확인 로직 포함
+
+BREAKING CHANGE: 기존 로그인 시 필수였던 username 파라미터가 제거됨
+```
+
+**Special:**
+- `!` suffix: Breaking changes를 나타냄 (major 버전 증가 요인)
+- `BREAKING CHANGE:` footer: 호환성 없는 변경사항 설명
+
+**Note:** When asked to write commit messages or PR descriptions, only output the message content without executing git commands. Do not include any AI-generated disclaimers or mentions that the content was created by AI.
+
+### Current Development Status
+- Basic entity structure in place with relationships:
+  - Member ↔ Participants ↔ Together (many-to-many through join entity)
+  - Together → Region (many-to-one)
+  - Member with status enum (ACTIVE, DORMANT, SUSPENDED, BANNED)
+- Repository layer exists but is empty
+- Main application includes test Hello class usage
+- Git branch: `feature/memeber-together-entity`

--- a/src/main/java/com/culturemate/culturemate_api/domain/Member.java
+++ b/src/main/java/com/culturemate/culturemate_api/domain/Member.java
@@ -1,0 +1,34 @@
+package com.culturemate.culturemate_api.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+public class Member {
+
+  @Id @GeneratedValue
+  @Column(name = "member_id")
+  private Long id;
+
+  @Column(unique = true)
+  private String login_id;
+
+  private String password;
+
+  @Enumerated(EnumType.STRING)
+  private Role role = Role.MEMBER;
+
+  private Instant joined_at;
+
+  @Enumerated(EnumType.STRING)
+  private MemberStatus status = MemberStatus.ACTIVE;
+
+  public void changeStatus() {
+    //TODO : 회원 제재 상태 변경
+  }
+
+}

--- a/src/main/java/com/culturemate/culturemate_api/domain/MemberStatus.java
+++ b/src/main/java/com/culturemate/culturemate_api/domain/MemberStatus.java
@@ -1,0 +1,8 @@
+package com.culturemate.culturemate_api.domain;
+
+public enum MemberStatus {
+  ACTIVE,       // 정상
+  DORMANT,      // 휴면
+  SUSPENDED,    // 일시 정지
+  BANNED        // 영구 정지
+}

--- a/src/main/java/com/culturemate/culturemate_api/domain/Participants.java
+++ b/src/main/java/com/culturemate/culturemate_api/domain/Participants.java
@@ -1,0 +1,25 @@
+package com.culturemate.culturemate_api.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+public class Participants {
+
+  @Id @GeneratedValue
+  @Column(name = "participant_id")
+  private Long id;
+
+  @Setter
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "together_id")
+  private Together together;
+
+  @Setter
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member participant;
+
+}

--- a/src/main/java/com/culturemate/culturemate_api/domain/Region.java
+++ b/src/main/java/com/culturemate/culturemate_api/domain/Region.java
@@ -1,0 +1,20 @@
+package com.culturemate.culturemate_api.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter @Setter
+public class Region {
+
+  @Id @GeneratedValue
+  private long id;
+
+  private String level1 = "전체"; // 시/도
+  private String level2 = "전체"; // 시/군/구
+  private String level3 = "전체"; // 읍/면/동
+
+}

--- a/src/main/java/com/culturemate/culturemate_api/domain/Role.java
+++ b/src/main/java/com/culturemate/culturemate_api/domain/Role.java
@@ -1,0 +1,5 @@
+package com.culturemate.culturemate_api.domain;
+
+public enum Role {
+  ADMIN, MEMBER
+}

--- a/src/main/java/com/culturemate/culturemate_api/domain/Together.java
+++ b/src/main/java/com/culturemate/culturemate_api/domain/Together.java
@@ -1,0 +1,56 @@
+package com.culturemate.culturemate_api.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Getter
+public class Together {
+
+  @Id @GeneratedValue
+  @Column(name = "together_id")
+  private long id;
+
+//  @ManyToOne
+//  @JoinColumn(name = "event_id")
+//  private Event event;
+
+  @ManyToOne
+  @JoinColumn(name = "host_id")
+  private Member host;
+
+  // OneToMany는 실제 저장되는 속성이 아니고, 관계 매핑용
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "together")
+  private List<Participants> participants;
+
+  private String title;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "region_id")
+  private Region region;
+
+  private String meeting_location;  // 모임 장소명
+  private String address;           // 기본 주소 (도로명 주소)
+  private String address_detail;    // 상세 주소
+
+  private LocalDate meeting_date;
+
+  private int max_participants;
+  private int current_participants;
+
+  @Column(length = 2000)
+  private String content;
+
+  private boolean is_recruiting = true;
+
+  private int interest_count = 0;
+
+  private Instant created_at;
+
+  private Instant modified_at;
+
+}

--- a/src/main/java/com/culturemate/culturemate_api/repository/MemberRepository.java
+++ b/src/main/java/com/culturemate/culturemate_api/repository/MemberRepository.java
@@ -1,0 +1,32 @@
+package com.culturemate.culturemate_api.repository;
+
+import com.culturemate.culturemate_api.domain.Member;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepository {
+
+  private final EntityManager em;
+
+  public void save(Member member) {
+    em.persist(member);
+  }
+
+  public Member findById(String id) {
+    return em.find(Member.class, id);
+  }
+
+  public Member findByLoginId(String loginId) {
+    return em.find(Member.class, loginId);
+  }
+
+  public List<Member> findAll() {
+    return em.createQuery("select m from Member m", Member.class).getResultList();
+  }
+
+}


### PR DESCRIPTION
  핵심 도메인 엔티티들과 JPA 매핑 관계를 구현

  - Member 엔티티: 사용자 정보 및 상태 관리
  - Together 엔티티: 문화활동 모임 정보
  - Participants 엔티티: 회원-모임 다대다 관계 중간 테이블
  - Region 엔티티: 지역 정보 (시/도/구 3단계)
  - Role, MemberStatus enum 추가

  주요 관계 설정:
  - Member ↔ Participants ↔ Together (다대다)
  - Together → Region (다대일)
  - Together → Member (host, 다대일)