### PR TITLE
!refactor: 이벤트 검색 API 통합 및 코드 정리

### DIFF
--- a/src/main/java/com/culturemate/culturemate_api/controller/EventController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/EventController.java
@@ -1,14 +1,12 @@
 package com.culturemate.culturemate_api.controller;
 
-import com.culturemate.culturemate_api.domain.Region;
 import com.culturemate.culturemate_api.domain.event.Event;
-import com.culturemate.culturemate_api.dto.EventSearchFilter;
+import com.culturemate.culturemate_api.dto.EventSearchDto;
 import com.culturemate.culturemate_api.service.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -37,76 +35,21 @@ public class EventController {
     }
   }
 
-  // 제목으로 이벤트 검색
+  // 통합 이벤트 검색 (제목, 지역, 날짜, 타입 모두 지원)
   @GetMapping("/search")
-  public ResponseEntity<?> getByTitle(@RequestParam String title) {
-    if (title == null || title.trim().isEmpty()) {
-      return ResponseEntity.badRequest().body("검색할 제목을 입력해주세요.");
-    }
+  public ResponseEntity<?> search(EventSearchDto searchDto) {
     try {
-      List<Event> events = eventService.readByTitle(title);
-      return ResponseEntity.ok().body(events);
-    } catch (Exception e) {
-      return ResponseEntity.badRequest().body("제목 검색 중 오류가 발생했습니다: " + e.getMessage());
-    }
-  }
-
-  // 지역으로 이벤트 검색
-  @GetMapping("/region")
-  public ResponseEntity<?> getByRegion(@RequestParam String level1,
-                                             @RequestParam(required = false) String level2,
-                                             @RequestParam(required = false) String level3) {
-    if (level1 == null || level1.trim().isEmpty()) {
-      return ResponseEntity.badRequest().body("지역 정보(level1)는 필수입니다.");
-    }
-    try {
-      List<Event> events = eventService.readByRegion(level1, level2, level3);
-      return ResponseEntity.ok().body(events);
-    } catch (Exception e) {
-      return ResponseEntity.badRequest().body("지역 검색 중 오류가 발생했습니다: " + e.getMessage());
-    }
-  }
-
-  // 복합 필터로 이벤트 검색
-  @GetMapping("/filter")
-  public ResponseEntity<?> getByFilter(
-      @RequestParam(required = false) String level1,
-      @RequestParam(required = false) String level2,
-      @RequestParam(required = false) String level3,
-      @RequestParam(required = false) String startDate,
-      @RequestParam(required = false) String endDate,
-      @RequestParam(required = false) String eventType
-  ) {
-    // 날짜 문자열을 LocalDate로 변환
-    LocalDate parsedStartDate = null;
-    LocalDate parsedEndDate = null;
-    
-    try {
-      if (startDate != null && !startDate.trim().isEmpty()) {
-        parsedStartDate = LocalDate.parse(startDate);
+      // 검색 조건이 비어있으면 전체 조회
+      if (searchDto.isEmpty()) {
+        List<Event> events = eventService.readAll();
+        return ResponseEntity.ok().body(events);
       }
-      if (endDate != null && !endDate.trim().isEmpty()) {
-        parsedEndDate = LocalDate.parse(endDate);
-      }
-    } catch (Exception e) {
-      return ResponseEntity.badRequest().body("날짜 형식이 올바르지 않습니다. (YYYY-MM-DD 형식을 사용해주세요)");
-    }
-    
-    // EventSearchFilter 객체 생성
-    EventSearchFilter filter = EventSearchFilter.builder()
-        .level1(level1)
-        .level2(level2)
-        .level3(level3)
-        .startDate(parsedStartDate)
-        .endDate(parsedEndDate)
-        .eventType(eventType)
-        .build();
-    
-    try {
-      List<Event> events = eventService.readByFilters(filter);
+      
+      List<Event> events = eventService.search(searchDto);
       return ResponseEntity.ok().body(events);
     } catch (Exception e) {
-      return ResponseEntity.badRequest().body("필터 검색 중 오류가 발생했습니다: " + e.getMessage());
+      return ResponseEntity.badRequest()
+          .body("이벤트 검색 중 오류가 발생했습니다: " + e.getMessage());
     }
   }
 

--- a/src/main/java/com/culturemate/culturemate_api/controller/EventReviewController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/EventReviewController.java
@@ -1,11 +1,10 @@
 package com.culturemate.culturemate_api.controller;
 
-import com.culturemate.culturemate_api.domain.Member;
 import com.culturemate.culturemate_api.domain.event.Event;
 import com.culturemate.culturemate_api.domain.event.EventReview;
+import com.culturemate.culturemate_api.domain.member.Member;
 import com.culturemate.culturemate_api.service.EventService;
 import com.culturemate.culturemate_api.service.EventReviewService;
-import com.culturemate.culturemate_api.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +17,7 @@ import java.util.List;
 public class EventReviewController {
   private final EventReviewService eventReviewService;
   private final EventService eventService;
-  private final MemberService memberService;
+//  private final MemberService memberService;
 
   // 특정 이벤트의 리뷰 데이터 조회
   @GetMapping
@@ -36,19 +35,19 @@ public class EventReviewController {
   }
 
   // 특정 회원이 작성한 리뷰 데이터 조회
-  @GetMapping("/member")
-  public ResponseEntity<?> getByMember(@RequestParam Long memberId) {
-    try {
-      Member member = memberService.read(memberId);
-      if (member == null) {
-        return ResponseEntity.notFound().build();
-      }
-      List<EventReview> reviews = eventReviewService.readByMember(member);
-      return ResponseEntity.ok().body(reviews);
-    } catch (Exception e) {
-      return ResponseEntity.badRequest().body("회원 리뷰 조회 중 오류가 발생했습니다: " + e.getMessage());
-    }
-  }
+//  @GetMapping("/member")
+//  public ResponseEntity<?> getByMember(@RequestParam Long memberId) {
+//    try {
+//      Member member = memberService.read(memberId);
+//      if (member == null) {
+//        return ResponseEntity.notFound().build();
+//      }
+//      List<EventReview> reviews = eventReviewService.readByMember(member);
+//      return ResponseEntity.ok().body(reviews);
+//    } catch (Exception e) {
+//      return ResponseEntity.badRequest().body("회원 리뷰 조회 중 오류가 발생했습니다: " + e.getMessage());
+//    }
+//  }
 
   // 이벤트 리뷰 등록
   @PostMapping

--- a/src/main/java/com/culturemate/culturemate_api/dto/EventSearchDto.java
+++ b/src/main/java/com/culturemate/culturemate_api/dto/EventSearchDto.java
@@ -1,0 +1,67 @@
+package com.culturemate.culturemate_api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventSearchDto {
+  
+  // 제목 검색
+  private String title;
+  
+  // 지역 검색
+  private String level1;
+  private String level2;
+  private String level3;
+  
+  // 날짜 범위 검색
+  @DateTimeFormat(pattern = "yyyy-MM-dd")
+  private LocalDate startDate;
+  
+  @DateTimeFormat(pattern = "yyyy-MM-dd")
+  private LocalDate endDate;
+  
+  // 이벤트 타입 검색
+  private String eventType;
+  
+  // 검증 및 유틸리티 메서드들
+  public boolean hasTitle() {
+    return title != null && !title.trim().isEmpty();
+  }
+  
+  public boolean hasRegion() {
+    return level1 != null && 
+           !level1.trim().isEmpty() && 
+           !"전체".equals(level1.trim());
+  }
+  
+  public boolean hasDateRange() {
+    return startDate != null || endDate != null;
+  }
+  
+  public boolean hasEventType() {
+    return eventType != null && !eventType.trim().isEmpty();
+  }
+  
+  public boolean isEmpty() {
+    return !hasTitle() && !hasRegion() && !hasDateRange() && !hasEventType();
+  }
+  
+  // 검색 조건 문자열 생성 (로깅용)
+  public String getSearchConditions() {
+    StringBuilder sb = new StringBuilder();
+    if (hasTitle()) sb.append("title:").append(title).append(" ");
+    if (hasRegion()) sb.append("region:").append(level1).append(" ");
+    if (hasDateRange()) sb.append("dates:").append(startDate).append("~").append(endDate).append(" ");
+    if (hasEventType()) sb.append("type:").append(eventType).append(" ");
+    return sb.toString().trim();
+  }
+}

--- a/src/main/java/com/culturemate/culturemate_api/dto/TogetherSearchFilter.java
+++ b/src/main/java/com/culturemate/culturemate_api/dto/TogetherSearchFilter.java
@@ -11,14 +11,14 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class EventSearchFilter {
+public class TogetherSearchFilter {
   private String level1;
   private String level2;
   private String level3;
   private LocalDate startDate;
   private LocalDate endDate;
   private String eventType;
-  
+
   public boolean hasRegion() {
     return level1 != null && 
            !level1.trim().isEmpty() && 

--- a/src/main/java/com/culturemate/culturemate_api/repository/EventRepository.java
+++ b/src/main/java/com/culturemate/culturemate_api/repository/EventRepository.java
@@ -38,37 +38,24 @@ import java.util.List;
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
 
-  List<Event> findByTitleContaining(String title);
-  
-  /**
-   * RegionRepository의 findRegionsByCondition()으로 찾은 지역들과 일치하는 이벤트 검색
-   */
-  @Query("SELECT e FROM Event e WHERE e.region IN :regions")
-  List<Event> findByRegion(@Param("regions") List<Region> regions);
-
-  List<Event> findByEventType(EventType eventType);
 
   /**
-   * 검색 기간과 겹치는 이벤트 조회 (startDate, endDate 필드 기반)
-   * 조건: 이벤트 시작일 <= 검색 종료일 AND 이벤트 종료일 >= 검색 시작일
-   */
-  @Query("SELECT e FROM Event e WHERE e.startDate <= :endDate AND e.endDate >= :startDate")
-  List<Event> findByPeriodBetween(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
-
-  /**
-   * 복합 조건으로 이벤트 검색
+   * 통합 검색: 제목 + 복합 조건으로 이벤트 검색
+   * - title: null이면 제목 조건 무시, 값이 있으면 LIKE 검색
    * - regions: null이면 지역 조건 무시
    * - startDate: null이면 시작일 조건 무시  
    * - endDate: null이면 종료일 조건 무시
    * - eventType: null이면 타입 조건 무시
    */
   @Query("SELECT e FROM Event e WHERE " +
+         "(:title IS NULL OR :title = '' OR e.title LIKE %:title%) AND " +
          "(:regions IS NULL OR e.region IN :regions) AND " +
          "(:startDate IS NULL OR e.endDate >= :startDate) AND " +
          "(:endDate IS NULL OR e.startDate <= :endDate) AND " +
          "(:eventType IS NULL OR e.eventType = :eventType)")
-  List<Event> findByFilters(@Param("regions") List<Region> regions,
-                           @Param("startDate") LocalDate startDate,
-                           @Param("endDate") LocalDate endDate,
-                           @Param("eventType") EventType eventType);
+  List<Event> findBySearch(@Param("title") String title,
+                          @Param("regions") List<Region> regions,
+                          @Param("startDate") LocalDate startDate,
+                          @Param("endDate") LocalDate endDate,
+                          @Param("eventType") EventType eventType);
 }

--- a/src/main/java/com/culturemate/culturemate_api/service/EventService.java
+++ b/src/main/java/com/culturemate/culturemate_api/service/EventService.java
@@ -3,7 +3,7 @@ package com.culturemate.culturemate_api.service;
 import com.culturemate.culturemate_api.domain.Region;
 import com.culturemate.culturemate_api.domain.event.Event;
 import com.culturemate.culturemate_api.domain.event.EventType;
-import com.culturemate.culturemate_api.dto.EventSearchFilter;
+import com.culturemate.culturemate_api.dto.EventSearchDto;
 import com.culturemate.culturemate_api.repository.EventRepository;
 import jakarta.persistence.EntityManager;
 import lombok.AccessLevel;
@@ -16,86 +16,61 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-@Transactional
+@Transactional(readOnly=true)
 public class EventService {
 
   private final EventRepository eventRepository;
   private final RegionService regionService;
 
+  @Transactional
   public Event create(Event event) {
     return eventRepository.save(event);
   }
 
-  @Transactional(readOnly = true)
   public Event read(Long eventId) {
     return eventRepository.findById(eventId).orElse(null);
   }
 
-  @Transactional(readOnly = true)
   public List<Event> readAll() {
     return eventRepository.findAll();
   }
 
-  // OverRide 객체기반 검색
-  @Transactional(readOnly = true)
-  public List<Event> readByRegion(Region region) {
-    List<Region> regionList
-      = regionService.readByCondition(region.getLevel1(), region.getLevel2(), region.getLevel3());
-    return eventRepository.findByRegion(regionList);
-  }
-  // OverRide 문자기반 검색
-  @Transactional(readOnly = true)
-  public List<Event> readByRegion(String level1, String level2, String level3) {
-    List<Region> regionList = regionService.readByCondition(level1, level2, level3);
-    return eventRepository.findByRegion(regionList);
-  }
-
-  @Transactional(readOnly = true)
-  public List<Event> readByType(EventType type) {
-    return eventRepository.findByEventType(type);
-  }
-
-  @Transactional(readOnly = true)
-  public List<Event> readByTitle(String title) {
-    return eventRepository.findByTitleContaining(title);
-  }
-
-  @Transactional(readOnly = true)
-  public List<Event> readByPeriodBetween(LocalDate start, LocalDate end) {
-    return eventRepository.findByPeriodBetween(start, end);
-  }
-
-  @Transactional(readOnly = true)
-  public List<Event> readByFilters(EventSearchFilter filter) {
+  // 새로운 통합 검색 메서드
+  public List<Event> search(EventSearchDto searchDto) {
     List<Region> regions = null;
-    if (filter.hasRegion()) {
+    if (searchDto.hasRegion()) {
       regions = regionService.readByCondition(
-        filter.getLevel1(),
-        filter.getLevel2(),
-        filter.getLevel3()
+        searchDto.getLevel1(),
+        searchDto.getLevel2(),
+        searchDto.getLevel3()
       );
     }
     
     EventType eventType = null;
-    if (filter.hasEventType()) {
-      eventType = EventType.valueOf(filter.getEventType());
+    if (searchDto.hasEventType()) {
+      eventType = EventType.valueOf(searchDto.getEventType().toUpperCase());
     }
     
-    return eventRepository.findByFilters(
+    // 새로운 통합 검색 Repository 메서드 사용
+    return eventRepository.findBySearch(
+      searchDto.hasTitle() ? searchDto.getTitle() : null,
       regions,
-      filter.getStartDate(),
-      filter.getEndDate(),
+      searchDto.getStartDate(),
+      searchDto.getEndDate(),
       eventType
     );
   }
 
+
+  @Transactional
   public void update(Event newEvent) {
     if(!eventRepository.existsById(newEvent.getId())) {
-      throw new IllegalArgumentException("이벤트가 존재하지 않습니다.");
+      throw new IllegalArgumentException("해당 이벤트가 존재하지 않습니다.");
     }
     eventRepository.save(newEvent);
   }
 
+  @Transactional
   public void delete(Long eventId) {
     eventRepository.deleteById(eventId);
   }

--- a/src/main/java/com/culturemate/culturemate_api/service/TogetherService.java
+++ b/src/main/java/com/culturemate/culturemate_api/service/TogetherService.java
@@ -1,0 +1,73 @@
+package com.culturemate.culturemate_api.service;
+
+import com.culturemate.culturemate_api.domain.event.Event;
+import com.culturemate.culturemate_api.domain.member.Member;
+import com.culturemate.culturemate_api.domain.together.Together;
+import com.culturemate.culturemate_api.dto.TogetherSearchFilter;
+import com.culturemate.culturemate_api.repository.TogetherRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly=true)
+public class TogetherService {
+
+  private final TogetherRepository togetherRepository;
+
+  @Transactional
+  public void create(Together together) {
+    togetherRepository.save(together);
+  }
+
+  public Together read(Long togetherId) {
+    return togetherRepository.findById(togetherId).orElse(null);
+  }
+
+  public List<Together> readAll() {
+    return togetherRepository.findAll();
+  }
+
+//  public List<Together> readByMember(Member member) {
+//
+//  }
+
+  public List<Together> readByEvent(Event event) {
+    return togetherRepository.findByEvent(event);
+  }
+
+  public List<Together> readByHost(Member host) {
+    return togetherRepository.findByHost(host);
+  }
+
+  // 호스트이든 동행인이든 상관없이 참여하는 동행을 불러옴
+  public List<Together> readByMember(Member member) {
+    return togetherRepository.findByParticipant(member);
+  }
+
+  public List<Together> readByTitle(String title) {
+    return togetherRepository.findByTitleContaining(title);
+  }
+
+  public List<Together> readByFilter(TogetherSearchFilter filter) {
+
+  }
+
+  @Transactional
+  public void update(Together newTogether) {
+    Together together = read(newTogether.getId());
+    if(together != null){
+      throw new IllegalArgumentException("해당 모집글이 존재하지 않습니다.");
+    }
+    togetherRepository.save(newTogether);
+  }
+
+  @Transactional
+  public void delete(Long togetherId) {
+    togetherRepository.deleteById(togetherId);
+  }
+
+}


### PR DESCRIPTION
  - EventSearchDto 추가로 통합 검색 기능 구현
  - Controller 중복 엔드포인트 제거 (/search, /region, /filter → /search)
  - Repository findBySearch 메서드로 제목+필터 조합 검색 지원
  - 불필요한 검색 메서드들 및 EventSearchFilter 클래스 제거
  - import 정리 및 코드 간소화

  BREAKING CHANGE: 기존 /events/region, /events/filter 엔드포인트 제거됨