### PR TITLE
refactor: member controller와 dto 정리

### DIFF
--- a/src/main/java/com/culturemate/culturemate_api/controller/MemberController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/MemberController.java
@@ -22,8 +22,8 @@ public class MemberController {
   // 회원 가입
   @PostMapping
   public ResponseEntity<MemberDto> create(@RequestBody MemberDto dto) {
-    MemberDto savedDto = memberService.create(dto);
-    return ResponseEntity.ok(savedDto);
+    Member savedMember = memberService.create(dto);
+    return ResponseEntity.ok(MemberDto.from(savedMember));
   }
 
   // 회원 삭제
@@ -36,25 +36,25 @@ public class MemberController {
   // 전체 회원 조회
   @GetMapping
   public List<MemberDto> getAllMembers(@RequestParam(defaultValue = "false") boolean isAdmin) {
-    return memberService.getAllMembers(isAdmin);
+    return memberService.findAllDto(isAdmin);
   }
 
   // ID로 회원 조회
   @GetMapping("/id/{id}")
   public ResponseEntity<MemberDto> getById(@PathVariable Long id) {
-    return ResponseEntity.ok(memberService.getById(id));
+    return ResponseEntity.ok(memberService.findByIdDto(id));
   }
 
   // 로그인 아이디로 회원 조회
   @GetMapping("/login/{loginId}")
   public ResponseEntity<MemberDto> findByLoginId(@PathVariable String loginId) {
-    return ResponseEntity.ok(memberService.findByLoginId(loginId));
+    return ResponseEntity.ok(memberService.findByLoginIdDto(loginId));
   }
 
   // 상태별 회원 목록 조회
   @GetMapping("/status/{status}")
   public ResponseEntity<List<MemberDto>> findByStatus(@PathVariable MemberStatus status) {
-    return ResponseEntity.ok(memberService.findByStatus(status));
+    return ResponseEntity.ok(memberService.findByStatusDto(status));
   }
 
   // 회원 상태 변경

--- a/src/main/java/com/culturemate/culturemate_api/controller/TogetherController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/TogetherController.java
@@ -26,35 +26,35 @@ public class TogetherController {
   @GetMapping
   public ResponseEntity<List<TogetherResponseDto>> getAll() {
     return ResponseEntity.ok().body(
-      togetherService.readAll().stream().map(TogetherResponseDto::from).collect(Collectors.toList())
+      togetherService.findAll().stream().map(TogetherResponseDto::from).collect(Collectors.toList())
     );
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<TogetherResponseDto> getById(@PathVariable Long id) {
-    Together together = togetherService.read(id);
+    Together together = togetherService.findById(id);
     return ResponseEntity.ok().body(TogetherResponseDto.from(together));
   }
 
   // 특정 회원이 호스트인 모집글 조회
   @GetMapping("/hosted-by/{hostId}")
   public ResponseEntity<List<TogetherResponseDto>> getByHostId(@PathVariable Long hostId) {
-    Member host = memberService.getById(hostId);
-    List<Together> togethers = togetherService.readByHost(host);
+    Member host = memberService.findById(hostId);
+    List<Together> togethers = togetherService.findByHost(host);
     return ResponseEntity.ok().body(togethers.stream().map(TogetherResponseDto::from).collect(Collectors.toList()));
   }
   // 특정 회원이 참여하는 모집글 조회
   @GetMapping("/with/{memberId}")
   public ResponseEntity<List<TogetherResponseDto>> getByMemberId(@PathVariable Long memberId) {
-    Member member = memberService.getById(memberId);
-    List<Together> togethers = togetherService.readByMember(member);
+    Member member = memberService.findById(memberId);
+    List<Together> togethers = togetherService.findByMember(member);
     return ResponseEntity.ok().body(togethers.stream().map(TogetherResponseDto::from).collect(Collectors.toList()));
   }
   // 모집글 통합 검색
   @GetMapping("/search")
   public ResponseEntity<List<TogetherResponseDto>> search(@RequestParam TogetherSearchDto searchDto) {
     if (searchDto.isEmpty()) {
-      List<Together> togethers = togetherService.readAll();
+      List<Together> togethers = togetherService.findAll();
       return ResponseEntity.ok().body(togethers.stream().map(TogetherResponseDto::from).collect(Collectors.toList()));
     }
 

--- a/src/main/java/com/culturemate/culturemate_api/dto/MemberDto.java
+++ b/src/main/java/com/culturemate/culturemate_api/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package com.culturemate.culturemate_api.dto;
 
+import com.culturemate.culturemate_api.domain.member.Member;
 import com.culturemate.culturemate_api.domain.member.MemberStatus;
 import com.culturemate.culturemate_api.domain.member.Role;
 import lombok.AllArgsConstructor;
@@ -17,4 +18,14 @@ public class MemberDto {
   private String password;     // Request 시 필요, Response 시는 null 처리 권장
   private Role role;           // Response 또는 Request에 따라 설정
   private MemberStatus status; // Response용, 생성 시 기본값 세팅 가능
+
+  // 간단한 Entity -> DTO 변환용 (컨트롤러에서 사용)
+  public static MemberDto from(Member member) {
+    return MemberDto.builder()
+      .id(member.getId())
+      .loginId(member.getLoginId())
+      .role(member.getRole())
+      .status(member.getStatus())
+      .build();
+  }
 }


### PR DESCRIPTION
컨트롤러와 서비스 계층에서 메서드명 표준화 및 dto 변환로직 분리/개선

  - MemberService: CRUD 메서드를 find* 패턴으로 통일 (getById → findById)
  - TogetherService: read* 메서드를 find* 패턴으로 통일 (read → findById, readAll → findAll)
  - MemberService: DTO 변환 로직을 내부 메서드로 분리하여 중복 제거
  - MemberDto: Entity → DTO 정적 팩토리 메서드 추가
  - 컨트롤러: 서비스 메서드명 변경에 따른 호출부 수정