### PR TITLE
feat: 사용자 관심 이벤트 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/culturemate/culturemate_api/controller/EventController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/EventController.java
@@ -156,6 +156,23 @@ public ResponseEntity<String> toggleEventInterest(
   }
 }
 
+  // 사용자 관심 이벤트 목록 조회
+  @GetMapping("/interests")
+  public ResponseEntity<List<EventDto.Response>> getUserInterestEvents(
+    @AuthenticationPrincipal AuthenticatedUser user) {
+    
+    if (user == null) {
+      return ResponseEntity.status(401).build(); // Unauthorized
+    }
+    
+    List<Event> interestEvents = eventService.getUserInterestEvents(user.getMemberId());
+    List<EventDto.Response> responseDtos = interestEvents.stream()
+      .map(event -> EventDto.Response.from(event, true)) // 모든 관심 이벤트는 isInterested = true
+      .toList();
+    
+    return ResponseEntity.ok(responseDtos);
+  }
+
   // 이벤트 삭제
   @DeleteMapping("/{id}")
   public ResponseEntity<Void> deleteEvent(@PathVariable Long id,

--- a/src/main/java/com/culturemate/culturemate_api/service/EventService.java
+++ b/src/main/java/com/culturemate/culturemate_api/service/EventService.java
@@ -381,6 +381,16 @@ public class EventService {
     return result;
   }
 
+  // 사용자 관심 이벤트 목록 조회
+  public List<Event> getUserInterestEvents(Long memberId) {
+    Member member = memberService.findById(memberId);
+    List<InterestEvents> interestEvents = interestEventsRepository.findByMember(member);
+    
+    return interestEvents.stream()
+      .map(InterestEvents::getEvent)
+      .toList();
+  }
+
   // ADMIN 권한 검증 메서드
   private void validateAdminAccess(Long requesterId) {
     Member requester = memberService.findById(requesterId);


### PR DESCRIPTION
 EventController에 GET /events/interests 엔드포인트를 추가하고,
 EventService에 getUserInterestEvents 메서드를 구현하여
 사용자가 관심 등록한 이벤트 목록을 조회할 수 있도록 함