### PR TITLE
feat: 회원가입 보안 강화 및 Together 도메인 아키텍처 개선

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Culture-Mate is a Spring Boot 3 service located under `src/main/java/com/culturemate/culturemate_api`. Core packages separate configuration, controllers, services, repositories, DTOs, and domain aggregates such as `event`, `member`, `community`, and `together`. Static assets and templates live in `src/main/resources`, while integration fixtures sit under `src/main/resources/static`. Mirror the production package layout when adding tests in `src/test/java/com/culturemate/culturemate_api` to keep navigation predictable.
+
+## Build, Test, and Development Commands
+Use the Gradle wrapper that ships with the repo. `./gradlew bootRun` starts the API with dev-time tooling and reads `.env`. `./gradlew build` produces a full artifact and runs the test suite. `./gradlew test` executes unit and slice tests; scope a single class with `./gradlew test --tests com.culturemate.culturemate_api.service.MemberServiceTest`. Run `./gradlew clean` before release builds to clear generated classes.
+
+## Coding Style & Naming Conventions
+Stick to Java 21 language features and 4-space indentation. Classes and enums use PascalCase, beans and methods stay camelCase, and constants remain UPPER_SNAKE_CASE. Place new code in the existing domain-driven packages and keep DTOs in `dto` with suffix `Request`/`Response`. Lombok is enabled; prefer `@Getter`, `@Builder`, and `@RequiredArgsConstructor` over manual boilerplate, but avoid Lombok on JPA entities where it clashes with lazy loading.
+
+## Testing Guidelines
+JUnit 5 is enabled through `useJUnitPlatform()`. Co-locate tests alongside their targets, name them `<Feature>Test`, and cover both success and failure paths for service and controller layers. For Spring MVC or WebSocket endpoints, lean on `@WebMvcTest` or `@SpringBootTest` plus MockMvc to validate request contracts. Include sample authentication tokens or stub repositories as needed so tests do not hit external services.
+
+## Commit & Pull Request Guidelines
+Follow the observed convention `type: short summary`, e.g., `feat: cancel participation flow`. Reference GitHub issues with `(#id)` when applicable and keep bodies bilingual only if it clarifies intent. Pull requests should describe the change, outline validation commands, and attach screenshots or API samples for user-facing updates. Ensure CI passes locally before requesting review.
+
+## Security & Configuration Tips
+Never commit `.env`; load database credentials through the provided `DB_URL`, `DB_USERNAME`, `DB_PASSWORD`, and `DB_DDL_AUTO` keys. The application defaults to in-memory H2 for development, but confirm Oracle connectivity in staging by overriding those variables. Keep JWT secrets and WebSocket origins configurable via environment properties, and update `CorsConfig` when adding new front-end hosts.

--- a/src/main/java/com/culturemate/culturemate_api/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/culturemate/culturemate_api/config/JwtAuthenticationFilter.java
@@ -2,7 +2,7 @@ package com.culturemate.culturemate_api.config;
 
 import com.culturemate.culturemate_api.domain.member.MemberStatus;
 import com.culturemate.culturemate_api.dto.AuthenticatedUser;
-import com.culturemate.culturemate_api.service.LoginService;
+import com.culturemate.culturemate_api.service.AuthService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,7 +24,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtUtil jwtUtil;
-  private final LoginService loginService;
+  private final AuthService authService;
 
   @Override
   protected void doFilterInternal(
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       try {
         if (jwtUtil.validateToken(token)) {
           String loginId = jwtUtil.getLoginIdFromToken(token);
-          UserDetails userDetails = loginService.loadUserByUsername(loginId);
+          UserDetails userDetails = authService.loadUserByUsername(loginId);
 
           // MemberStatus 검증 추가
           if (userDetails instanceof AuthenticatedUser) {

--- a/src/main/java/com/culturemate/culturemate_api/config/JwtUtil.java
+++ b/src/main/java/com/culturemate/culturemate_api/config/JwtUtil.java
@@ -19,10 +19,10 @@ import java.util.Map;
 @Slf4j
 public class JwtUtil {
 
-  @Value("${jwt.secret:myDefaultSecretKey123456789012345678901234567890}")
+  @Value("${jwt.secret}")
   private String secret;
 
-  @Value("${jwt.expiration:86400000}") // 24시간 (milliseconds)
+  @Value("${jwt.expiration}") // 24시간 (milliseconds)
   private Long expiration;
 
   private SecretKey getSigningKey() {

--- a/src/main/java/com/culturemate/culturemate_api/controller/AuthController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/AuthController.java
@@ -1,8 +1,11 @@
 package com.culturemate.culturemate_api.controller;
 
 import com.culturemate.culturemate_api.config.JwtUtil;
+import com.culturemate.culturemate_api.domain.member.Member;
 import com.culturemate.culturemate_api.dto.AuthenticatedUser;
 import com.culturemate.culturemate_api.dto.MemberDto;
+import com.culturemate.culturemate_api.service.AuthService;
+import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,10 +29,11 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class AuthApiController {
+public class AuthController {
 
   private final AuthenticationManager authenticationManager;
   private final JwtUtil jwtUtil;
+  private final AuthService authService;
 
   @Operation(summary = "로그인", description = "회원 로그인을 수행하고 JWT 토큰을 반환합니다")
   @ApiResponses(value = {
@@ -69,5 +73,18 @@ public class AuthApiController {
       errorResponse.put("message", "아이디 또는 비밀번호가 일치하지 않습니다.");
       return ResponseEntity.status(401).body(errorResponse);
     }
+  }
+
+  @Operation(summary = "회원 가입", description = "새로운 회원을 등록합니다")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "201", description = "가입 성공"),
+    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+    @ApiResponse(responseCode = "409", description = "이미 존재하는 회원")
+  })
+  @PostMapping("/register")
+  public ResponseEntity<MemberDto.Response> register(
+    @Parameter(description = "회원 가입 정보", required = true) @Valid @RequestBody MemberDto.Register registerDto) {
+    Member savedMember = authService.register(registerDto);
+    return ResponseEntity.status(201).body(MemberDto.Response.from(savedMember));
   }
 }

--- a/src/main/java/com/culturemate/culturemate_api/controller/AuthController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.culturemate.culturemate_api.domain.member.Member;
 import com.culturemate.culturemate_api.dto.AuthenticatedUser;
 import com.culturemate.culturemate_api.dto.MemberDto;
 import com.culturemate.culturemate_api.service.AuthService;
+import com.culturemate.culturemate_api.service.MemberService;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -34,6 +35,7 @@ public class AuthController {
   private final AuthenticationManager authenticationManager;
   private final JwtUtil jwtUtil;
   private final AuthService authService;
+  private final MemberService memberService;
 
   @Operation(summary = "로그인", description = "회원 로그인을 수행하고 JWT 토큰을 반환합니다")
   @ApiResponses(value = {
@@ -84,7 +86,7 @@ public class AuthController {
   @PostMapping("/register")
   public ResponseEntity<MemberDto.Response> register(
     @Parameter(description = "회원 가입 정보", required = true) @Valid @RequestBody MemberDto.Register registerDto) {
-    Member savedMember = authService.register(registerDto);
+    Member savedMember = memberService.register(registerDto);
     return ResponseEntity.status(201).body(MemberDto.Response.from(savedMember));
   }
 }

--- a/src/main/java/com/culturemate/culturemate_api/controller/AuthController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.culturemate.culturemate_api.dto.AuthenticatedUser;
 import com.culturemate.culturemate_api.dto.MemberDto;
 import com.culturemate.culturemate_api.service.AuthService;
 import com.culturemate.culturemate_api.service.MemberService;
+import com.culturemate.culturemate_api.service.MemberDetailService;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,6 +22,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
@@ -36,6 +39,7 @@ public class AuthController {
   private final JwtUtil jwtUtil;
   private final AuthService authService;
   private final MemberService memberService;
+  private final MemberDetailService memberDetailService;
 
   @Operation(summary = "로그인", description = "회원 로그인을 수행하고 JWT 토큰을 반환합니다")
   @ApiResponses(value = {
@@ -88,5 +92,41 @@ public class AuthController {
     @Parameter(description = "회원 가입 정보", required = true) @Valid @RequestBody MemberDto.Register registerDto) {
     Member savedMember = memberService.register(registerDto);
     return ResponseEntity.status(201).body(MemberDto.Response.from(savedMember));
+  }
+
+  @Operation(summary = "아이디 중복 확인", description = "로그인 아이디 중복 여부를 확인합니다")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "중복 확인 완료"),
+    @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
+  @GetMapping("/check-login-id")
+  public ResponseEntity<Map<String, Object>> checkLoginIdDuplicate(
+    @Parameter(description = "확인할 로그인 아이디", required = true) @RequestParam String loginId) {
+
+    boolean isDuplicate = memberService.existsByLoginId(loginId);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("isDuplicate", isDuplicate);
+    response.put("message", isDuplicate ? "이미 사용 중인 아이디입니다." : "사용 가능한 아이디입니다.");
+
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "이메일 중복 확인", description = "이메일 중복 여부를 확인합니다")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "200", description = "중복 확인 완료"),
+    @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
+  @GetMapping("/check-email")
+  public ResponseEntity<Map<String, Object>> checkEmailDuplicate(
+    @Parameter(description = "확인할 이메일", required = true) @RequestParam String email) {
+
+    boolean isDuplicate = memberDetailService.existsByEmail(email);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("isDuplicate", isDuplicate);
+    response.put("message", isDuplicate ? "이미 사용 중인 이메일입니다." : "사용 가능한 이메일입니다.");
+
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/culturemate/culturemate_api/controller/InquiryAdminController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/InquiryAdminController.java
@@ -25,11 +25,16 @@ public class InquiryAdminController {
     @GetMapping
     public ResponseEntity<List<InquiryDto.ListResponse>> getAllInquiries(
             @AuthenticationPrincipal AuthenticatedUser admin) {
-        
+
         var inquiries = inquiryService.getAllInquiries(admin.getMemberId());
-        return ResponseEntity.ok(inquiries.stream()
-                .map(InquiryDto.ListResponse::from)
-                .collect(Collectors.toList()));
+        List<InquiryDto.ListResponse> responses = inquiries.stream()
+          .map(inquiry -> {
+            List<String> imageUrls = inquiryService.getInquiryImagePaths(inquiry.getId());
+            return InquiryDto.ListResponse.from(inquiry, imageUrls);
+          })
+          .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responses);
     }
 
     @PostMapping("/{inquiryId}/answer")
@@ -37,8 +42,9 @@ public class InquiryAdminController {
             @PathVariable Long inquiryId,
             @Valid @RequestBody InquiryAnswerDto.CreateRequest request,
             @AuthenticationPrincipal AuthenticatedUser admin) {
-        
+
         var inquiry = inquiryService.createOrUpdateAnswer(inquiryId, request, admin.getMemberId());
-        return ResponseEntity.ok(InquiryDto.Response.from(inquiry));
+        List<String> imageUrls = inquiryService.getInquiryImagePaths(inquiry.getId());
+        return ResponseEntity.ok(InquiryDto.Response.from(inquiry, imageUrls));
     }
 }

--- a/src/main/java/com/culturemate/culturemate_api/controller/InquiryController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/InquiryController.java
@@ -33,7 +33,8 @@ public class InquiryController {
             @AuthenticationPrincipal AuthenticatedUser user) {
 
         Inquiry inquiry = inquiryService.createInquiry(request, images, user.getMemberId());
-        return ResponseEntity.ok(InquiryDto.Response.from(inquiry));
+        List<String> imageUrls = inquiryService.getInquiryImagePaths(inquiry.getId());
+        return ResponseEntity.ok(InquiryDto.Response.from(inquiry, imageUrls));
     }
 
   @GetMapping("/my")
@@ -47,9 +48,14 @@ public class InquiryController {
       inquiries = inquiryService.getMyInquiries(user.getMemberId());
     }
 
-    return ResponseEntity.ok(
-      inquiries.stream().map(InquiryDto.ListResponse::from).collect(Collectors.toList())
-    );
+    List<InquiryDto.ListResponse> responses = inquiries.stream()
+      .map(inquiry -> {
+        List<String> imageUrls = inquiryService.getInquiryImagePaths(inquiry.getId());
+        return InquiryDto.ListResponse.from(inquiry, imageUrls);
+      })
+      .collect(Collectors.toList());
+
+    return ResponseEntity.ok(responses);
   }
 
 //    @GetMapping("/{inquiryId}")
@@ -61,28 +67,4 @@ public class InquiryController {
 //        return ResponseEntity.ok(InquiryDto.Response.from(inquiry));
 //    }
 
-  // 관리자 전용: 전체 문의 조회
-  @GetMapping("/all")
-  public ResponseEntity<List<InquiryDto.ListResponse>> getAllInquiries(
-    @AuthenticationPrincipal AuthenticatedUser user) {
-
-    // InquiryService에서 admin 체크 포함
-    var inquiries = inquiryService.getAllInquiries(user.getMemberId());
-    return ResponseEntity.ok(
-      inquiries.stream()
-        .map(InquiryDto.ListResponse::from)
-        .collect(Collectors.toList())
-    );
-  }
-
-  // 관리자 전용 : 답변
-  @PostMapping("/{inquiryId}/answer")
-  public ResponseEntity<InquiryDto.Response> createOrUpdateAnswer(
-    @PathVariable Long inquiryId,
-    @RequestBody InquiryAnswerDto.CreateRequest dto,
-    @AuthenticationPrincipal AuthenticatedUser user) {
-
-    var inquiry = inquiryService.createOrUpdateAnswer(inquiryId, dto, user.getMemberId());
-    return ResponseEntity.ok(InquiryDto.Response.from(inquiry));
-  }
 }

--- a/src/main/java/com/culturemate/culturemate_api/controller/MemberController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/MemberController.java
@@ -27,19 +27,6 @@ import java.util.stream.Collectors;
 public class MemberController {
   private final MemberService memberService;
 
-  @Operation(summary = "회원 가입", description = "새로운 회원을 등록합니다")
-  @ApiResponses(value = {
-    @ApiResponse(responseCode = "201", description = "가입 성공"),
-    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-    @ApiResponse(responseCode = "409", description = "이미 존재하는 회원")
-  })
-  @PostMapping
-  public ResponseEntity<MemberDto.Response> registerMember(
-    @Parameter(description = "회원 가입 정보", required = true) @Valid @RequestBody MemberDto.Register registerDto) {
-    Member savedMember = memberService.create(registerDto);
-    return ResponseEntity.status(201).body(MemberDto.Response.from(savedMember));
-  }
-
   // 회원 삭제
   @DeleteMapping("/{memberId}")
   public ResponseEntity<Void> deleteMember(@PathVariable Long memberId) {

--- a/src/main/java/com/culturemate/culturemate_api/controller/MemberDetailController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/MemberDetailController.java
@@ -167,7 +167,8 @@ public class MemberDetailController {
                                                        @RequestBody Map<String, List<String>> requestBody,
                                                        @AuthenticationPrincipal AuthenticatedUser requester) {
     List<String> eventTypes = requestBody.get("eventTypes");
-    memberDetailService.updateInterestEventTypes(memberId, eventTypes, requester.getMemberId());
+    authService.validateProfileAccess(memberId, requester.getMemberId());
+    memberDetailService.updateInterestEventTypes(memberId, eventTypes);
     return ResponseEntity.ok().build();
   }
 
@@ -177,7 +178,8 @@ public class MemberDetailController {
                                                  @RequestBody Map<String, List<String>> requestBody,
                                                  @AuthenticationPrincipal AuthenticatedUser requester) {
     List<String> tags = requestBody.get("tags");
-    memberDetailService.updateInterestTags(memberId, tags, requester.getMemberId());
+    authService.validateProfileAccess(memberId, requester.getMemberId());
+    memberDetailService.updateInterestTags(memberId, tags);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/com/culturemate/culturemate_api/controller/MemberDetailController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/MemberDetailController.java
@@ -6,6 +6,7 @@ import com.culturemate.culturemate_api.dto.AuthenticatedUser;
 import com.culturemate.culturemate_api.dto.MemberDto;
 import com.culturemate.culturemate_api.domain.Image;
 import com.culturemate.culturemate_api.domain.ImageTarget;
+import com.culturemate.culturemate_api.service.AuthService;
 import com.culturemate.culturemate_api.service.ImageService;
 import com.culturemate.culturemate_api.service.ImagePermissionService;
 import com.culturemate.culturemate_api.service.MemberDetailService;
@@ -29,6 +30,7 @@ public class MemberDetailController {
 
   private final MemberDetailService memberDetailService;
   private final MemberService memberService;
+  private final AuthService authService;
   private final ImageService imageService;
   private final ImagePermissionService imagePermissionService;
 
@@ -53,7 +55,8 @@ public class MemberDetailController {
   public ResponseEntity<MemberDto.DetailResponse> updateMemberDetail(@PathVariable Long memberId,
                                                        @Valid @RequestBody MemberDto.DetailRequest dto,
                                                        @AuthenticationPrincipal AuthenticatedUser requester) {
-    MemberDetail updated = memberDetailService.update(memberId, dto, requester.getMemberId());
+    authService.validateProfileAccess(memberId, requester.getMemberId());
+    MemberDetail updated = memberDetailService.update(memberId, dto);
     return ResponseEntity.ok(MemberDto.DetailResponse.from(updated));  // HTTP 200 OK + 데이터 반환
   }
 
@@ -61,7 +64,8 @@ public class MemberDetailController {
   @DeleteMapping("/{memberId}")
   public ResponseEntity<Void> deleteMemberDetail(@PathVariable Long memberId,
                                                  @AuthenticationPrincipal AuthenticatedUser requester) {
-    memberDetailService.delete(memberId, requester.getMemberId());
+    authService.validateProfileAccess(memberId, requester.getMemberId());
+    memberDetailService.delete(memberId);
     return ResponseEntity.noContent().build();  // HTTP 204 No Content
   }
 
@@ -75,10 +79,12 @@ public class MemberDetailController {
                                           @AuthenticationPrincipal AuthenticatedUser user) {
     switch (imageType.toLowerCase()) {
       case "profile":
-        memberDetailService.updateProfileImage(memberId, imageFile, user.getMemberId());
+        authService.validateProfileAccess(memberId, user.getMemberId());
+        memberDetailService.updateProfileImage(memberId, imageFile);
         break;
       case "background":
-        memberDetailService.updateBackgroundImage(memberId, imageFile, user.getMemberId());
+        authService.validateProfileAccess(memberId, user.getMemberId());
+        memberDetailService.updateBackgroundImage(memberId, imageFile);
         break;
       default:
         throw new IllegalArgumentException("지원하지 않는 이미지 타입입니다: " + imageType + " (사용 가능: profile, background)");
@@ -93,10 +99,12 @@ public class MemberDetailController {
                                           @AuthenticationPrincipal AuthenticatedUser user) {
     switch (imageType.toLowerCase()) {
       case "profile":
-        memberDetailService.deleteProfileImage(memberId, user.getMemberId());
+        authService.validateProfileAccess(memberId, user.getMemberId());
+        memberDetailService.deleteProfileImage(memberId);
         break;
       case "background":
-        memberDetailService.deleteBackgroundImage(memberId, user.getMemberId());
+        authService.validateProfileAccess(memberId, user.getMemberId());
+        memberDetailService.deleteBackgroundImage(memberId);
         break;
       default:
         throw new IllegalArgumentException("지원하지 않는 이미지 타입입니다: " + imageType + " (사용 가능: profile, background)");

--- a/src/main/java/com/culturemate/culturemate_api/controller/TogetherController.java
+++ b/src/main/java/com/culturemate/culturemate_api/controller/TogetherController.java
@@ -8,6 +8,7 @@ import com.culturemate.culturemate_api.domain.together.ParticipationStatus;
 import com.culturemate.culturemate_api.domain.together.Together;
 import com.culturemate.culturemate_api.dto.*;
 import com.culturemate.culturemate_api.repository.ParticipantsRepository;
+import com.culturemate.culturemate_api.facade.TogetherFacade;
 import com.culturemate.culturemate_api.service.ChatRoomService;
 import com.culturemate.culturemate_api.service.MemberService;
 import com.culturemate.culturemate_api.service.TogetherService;
@@ -33,6 +34,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class TogetherController {
   private final TogetherService togetherService;
+  private final TogetherFacade togetherFacade;
   private final MemberService memberService;
   private final ChatRoomService chatRoomService;
   private final ParticipantsRepository participantsRepository;
@@ -119,7 +121,7 @@ public class TogetherController {
   // 모집글 생성
   @PostMapping
   public ResponseEntity<TogetherDto.Response> createTogether(@Valid @RequestBody TogetherDto.Request togetherRequestDto) {
-    Together together = togetherService.create(togetherRequestDto);
+    Together together = togetherFacade.createTogetherWithChatRoom(togetherRequestDto);
     return ResponseEntity.ok().body(togetherService.toResponseDto(together));
   }
 
@@ -136,7 +138,7 @@ public class TogetherController {
   @DeleteMapping("/{togetherId}")
   public ResponseEntity<Void> deleteTogether(@PathVariable Long togetherId,
                                             @AuthenticationPrincipal AuthenticatedUser requester) {
-    togetherService.delete(togetherId, requester.getMemberId());
+    togetherFacade.deleteTogetherWithRelatedData(togetherId, requester.getMemberId());
     return ResponseEntity.noContent().build();
   }
 
@@ -172,7 +174,7 @@ public class TogetherController {
   public ResponseEntity<Void> approveParticipation(@PathVariable Long togetherId,
                                                    @PathVariable Long participantId,
                                                    @AuthenticationPrincipal AuthenticatedUser requester) {
-    togetherService.approveParticipation(togetherId, participantId, requester.getMemberId());
+    togetherFacade.approveParticipationWithChatRoom(togetherId, participantId, requester.getMemberId());
     return ResponseEntity.ok().build();
   }
 
@@ -181,7 +183,7 @@ public class TogetherController {
   public ResponseEntity<Void> rejectParticipation(@PathVariable Long togetherId,
                                                   @PathVariable Long participantId,
                                                   @AuthenticationPrincipal AuthenticatedUser requester) {
-    togetherService.rejectParticipation(togetherId, participantId, requester.getMemberId());
+    togetherFacade.rejectParticipation(togetherId, participantId, requester.getMemberId());
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/com/culturemate/culturemate_api/domain/inquiry/Inquiry.java
+++ b/src/main/java/com/culturemate/culturemate_api/domain/inquiry/Inquiry.java
@@ -33,10 +33,8 @@ public class Inquiry {
     @Column(nullable = false, length = 3000)
     private String content;
 
-    @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true)
-    @JoinColumn(name = "targetId")
-    @Builder.Default
-    private List<Image> images = new ArrayList<>();
+    // 이미지는 ImageService를 통해 targetType=INQUIRY, targetId=this.id로 관리
+    // 다른 엔티티들과 동일한 패턴 사용
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/culturemate/culturemate_api/domain/inquiry/InquiryCategory.java
+++ b/src/main/java/com/culturemate/culturemate_api/domain/inquiry/InquiryCategory.java
@@ -1,7 +1,5 @@
 package com.culturemate.culturemate_api.domain.inquiry;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-
 public enum InquiryCategory {
     QUESTION,     // 문의
     SUGGESTION,   // 건의
@@ -9,18 +7,5 @@ public enum InquiryCategory {
     SITE_USAGE,   // 사이트이용
     REPORT,       // 신고
     EVENT,        // 이벤트 관련
-    ETC;           // 기타
-
-    @JsonCreator
-    public static InquiryCategory fromString(String value) {
-        if (value == null) {
-            return null;
-        }
-        for (InquiryCategory category : InquiryCategory.values()) {
-            if (category.name().equalsIgnoreCase(value)) {
-                return category;
-            }
-        }
-        throw new IllegalArgumentException("Unknown enum type " + value + ", Allowed values are " + java.util.Arrays.toString(values()));
-    }
+    ETC           // 기타
 }

--- a/src/main/java/com/culturemate/culturemate_api/dto/InquiryAnswerDto.java
+++ b/src/main/java/com/culturemate/culturemate_api/dto/InquiryAnswerDto.java
@@ -1,6 +1,7 @@
 package com.culturemate.culturemate_api.dto;
 
 import com.culturemate.culturemate_api.domain.inquiry.InquiryAnswer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,12 +9,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public class InquiryAnswerDto {
 
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "InquiryAnswerRequest", description = "1:1 문의 답변 생성/수정 요청 DTO")
     public static class CreateRequest {
         @NotBlank(message = "답변 내용을 입력해주세요.")
         private String content;
@@ -21,20 +25,22 @@ public class InquiryAnswerDto {
 
     @Getter
     @Builder
+    @Schema(name = "InquiryAnswerResponse", description = "1:1 문의 답변 정보 응답 DTO")
     public static class Response {
         private Long answerId;
         private String content;
         private MemberDto.ProfileResponse author;
-        private Instant createdAt;
-        private Instant updatedAt;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
 
         public static Response from(InquiryAnswer answer) {
             return Response.builder()
                     .answerId(answer.getId())
                     .content(answer.getContent())
                     .author(MemberDto.ProfileResponse.from(answer.getAuthor()))
-                    .createdAt(answer.getCreatedAt())
-                    .updatedAt(answer.getUpdatedAt())
+                    .createdAt(answer.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime())
+                    .updatedAt(answer.getUpdatedAt() != null ?
+                        answer.getUpdatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime() : null)
                     .build();
         }
     }

--- a/src/main/java/com/culturemate/culturemate_api/dto/InquiryDto.java
+++ b/src/main/java/com/culturemate/culturemate_api/dto/InquiryDto.java
@@ -1,10 +1,10 @@
 package com.culturemate.culturemate_api.dto;
 
-import com.culturemate.culturemate_api.domain.Image;
 import com.culturemate.culturemate_api.domain.inquiry.Inquiry;
 import com.culturemate.culturemate_api.domain.inquiry.InquiryCategory;
 import com.culturemate.culturemate_api.domain.inquiry.InquiryStatus;
-import com.culturemate.culturemate_api.domain.member.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -13,14 +13,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class InquiryDto {
 
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "InquiryRequest", description = "1:1 문의 생성 요청 DTO")
     public static class CreateRequest {
         @NotBlank(message = "제목을 입력해주세요.")
         private String title;
@@ -34,6 +36,7 @@ public class InquiryDto {
 
     @Getter
     @Builder
+    @Schema(name = "InquiryResponse", description = "1:1 문의 상세 정보 응답 DTO")
     public static class Response {
         private Long inquiryId;
         private String title;
@@ -41,10 +44,9 @@ public class InquiryDto {
         private MemberDto.ProfileResponse author;
         private InquiryCategory category;
         private InquiryStatus status;
-        private Instant createdAt;
+        private LocalDateTime createdAt;
         private InquiryAnswerDto.Response answer;
         private List<String> imageUrls;
-        private Role role;
 
         public static Response from(Inquiry inquiry) {
             return Response.builder()
@@ -52,29 +54,40 @@ public class InquiryDto {
                     .title(inquiry.getTitle())
                     .content(inquiry.getContent())
                     .author(MemberDto.ProfileResponse.from(inquiry.getAuthor()))
-                    .role(inquiry.getAuthor().getRole())
                     .category(inquiry.getCategory())
                     .status(inquiry.getStatus())
-                    .createdAt(inquiry.getCreatedAt())
+                    .createdAt(inquiry.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime())
                     .answer(inquiry.getAnswer() != null ? InquiryAnswerDto.Response.from(inquiry.getAnswer()) : null)
-                    .imageUrls(inquiry.getImages() != null
-                    ? inquiry.getImages().stream().map(Image::getPath).collect(Collectors.toList())
-                    : List.of())
+                    .imageUrls(List.of()) // 기본값, 필요시 withImages 메서드 사용
+                    .build();
+        }
+
+        public static Response from(Inquiry inquiry, List<String> imageUrls) {
+            return Response.builder()
+                    .inquiryId(inquiry.getId())
+                    .title(inquiry.getTitle())
+                    .content(inquiry.getContent())
+                    .author(MemberDto.ProfileResponse.from(inquiry.getAuthor()))
+                    .category(inquiry.getCategory())
+                    .status(inquiry.getStatus())
+                    .createdAt(inquiry.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime())
+                    .answer(inquiry.getAnswer() != null ? InquiryAnswerDto.Response.from(inquiry.getAnswer()) : null)
+                    .imageUrls(imageUrls)
                     .build();
         }
     }
     
     @Getter
     @Builder
+    @Schema(name = "InquiryListResponse", description = "1:1 문의 목록 응답 DTO")
     public static class ListResponse {
         private Long inquiryId;
         private String title;
         private String content;
         private MemberDto.ProfileResponse author;
-        private Role role;
         private InquiryCategory category;
         private InquiryStatus status;
-        private Instant createdAt;
+        private LocalDateTime createdAt;
         private InquiryAnswerDto.Response answer;
         private List<String> imageUrls;
 
@@ -84,18 +97,29 @@ public class InquiryDto {
                     .title(inquiry.getTitle())
                     .content(inquiry.getContent())
                     .author(MemberDto.ProfileResponse.from(inquiry.getAuthor()))
-                    .role(inquiry.getAuthor().getRole())
                     .category(inquiry.getCategory())
                     .status(inquiry.getStatus())
-                    .createdAt(inquiry.getCreatedAt())
+                    .createdAt(inquiry.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime())
                     .answer(inquiry.getAnswer() != null
                     ? InquiryAnswerDto.Response.from(inquiry.getAnswer())
                     : null)
-                    .imageUrls(inquiry.getImages() != null
-                    ? inquiry.getImages().stream()
-                    .map(Image::getPath)
-                    .collect(Collectors.toList())
-                    : List.of())
+                    .imageUrls(List.of()) // 기본값, 필요시 withImages 메서드 사용
+                    .build();
+        }
+
+        public static ListResponse from(Inquiry inquiry, List<String> imageUrls) {
+            return ListResponse.builder()
+                    .inquiryId(inquiry.getId())
+                    .title(inquiry.getTitle())
+                    .content(inquiry.getContent())
+                    .author(MemberDto.ProfileResponse.from(inquiry.getAuthor()))
+                    .category(inquiry.getCategory())
+                    .status(inquiry.getStatus())
+                    .createdAt(inquiry.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime())
+                    .answer(inquiry.getAnswer() != null
+                    ? InquiryAnswerDto.Response.from(inquiry.getAnswer())
+                    : null)
+                    .imageUrls(imageUrls)
                     .build();
         }
     }

--- a/src/main/java/com/culturemate/culturemate_api/dto/MemberDto.java
+++ b/src/main/java/com/culturemate/culturemate_api/dto/MemberDto.java
@@ -38,7 +38,9 @@ public class MemberDto {
     private String loginId;
 
     @NotBlank
-    @Size(min = 8, max = 100, message = "비밀번호는 8자 이상이어야 합니다.")
+    @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=.,?])[a-zA-Z\\d!@#$%^&*()_+\\-=.,?]+$",
+             message = "비밀번호는 영문, 숫자, 특수문자(!@#$%^&*()_+-=.,?)를 각각 1개 이상 포함해야 합니다.")
     private String password;
 
     @NotBlank

--- a/src/main/java/com/culturemate/culturemate_api/facade/TogetherFacade.java
+++ b/src/main/java/com/culturemate/culturemate_api/facade/TogetherFacade.java
@@ -1,0 +1,118 @@
+package com.culturemate.culturemate_api.facade;
+
+import com.culturemate.culturemate_api.domain.chatting.ChatRoom;
+import com.culturemate.culturemate_api.domain.event.Event;
+import com.culturemate.culturemate_api.domain.member.Member;
+import com.culturemate.culturemate_api.domain.Region;
+import com.culturemate.culturemate_api.domain.together.Together;
+import com.culturemate.culturemate_api.dto.TogetherDto;
+import com.culturemate.culturemate_api.service.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Together 관련 복합 비즈니스 로직을 처리하는 Facade
+ * - 여러 서비스를 조합하여 복잡한 워크플로우 제공
+ * - Controller의 복잡성 제거
+ * - 트랜잭션 경계 관리
+ */
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TogetherFacade {
+
+  private final TogetherService togetherService;
+  private final MemberService memberService;
+  private final EventService eventService;
+  private final RegionService regionService;
+  private final ChatRoomService chatRoomService;
+
+  /**
+   * Together 생성과 동시에 채팅방 생성 및 호스트 참여 처리
+   * - Together 엔티티 생성
+   * - 호스트를 참여자로 자동 추가
+   * - 채팅방 생성 및 호스트 추가
+   *
+   * @param requestDto Together 생성 요청 데이터
+   * @return 생성된 Together 엔티티
+   */
+  @Transactional
+  public Together createTogetherWithChatRoom(TogetherDto.Request requestDto) {
+    // 1. 필요한 엔티티들 조회
+    Event event = eventService.findById(requestDto.getEventId());
+    Member host = memberService.findById(requestDto.getHostId());
+    Region region = regionService.findExact(requestDto.getRegion());
+
+    // 2. Together 생성 (호스트 참여자 추가 포함)
+    Together savedTogether = togetherService.create(event, host, region, requestDto);
+
+    // 3. 채팅방 생성 및 호스트 추가
+    ChatRoom chatRoom = chatRoomService.createChatRoom(savedTogether);
+    chatRoomService.addMemberToRoom(chatRoom.getId(), host.getId());
+
+    return savedTogether;
+  }
+
+  /**
+   * 참여 승인과 동시에 채팅방 참여 처리
+   * - 참여 상태를 APPROVED로 변경
+   * - 채팅방에 참여자 추가
+   * - 알림 발송 등 추가 처리 가능
+   *
+   * @param togetherId Together ID
+   * @param participantId 참여자 ID
+   * @param hostId 호스트 ID (권한 검증용)
+   */
+  @Transactional
+  public void approveParticipationWithChatRoom(Long togetherId, Long participantId, Long hostId) {
+    // 1. 참여 승인 처리 (권한 검증 포함)
+    togetherService.approveParticipation(togetherId, participantId, hostId);
+
+    // 2. 채팅방에 참여자 추가
+    Together together = togetherService.findById(togetherId);
+    ChatRoom chatRoom = chatRoomService.findGroupChatByTogether(together);
+    chatRoomService.addMemberToRoom(chatRoom.getId(), participantId);
+
+    // 3. 추가 처리 (알림 등) - 향후 확장 가능
+    // notificationService.notifyParticipationApproved(together, participantId);
+  }
+
+  /**
+   * 참여 거절 처리
+   * - 참여 상태를 REJECTED로 변경
+   * - 필요시 알림 발송
+   *
+   * @param togetherId Together ID
+   * @param participantId 참여자 ID
+   * @param hostId 호스트 ID (권한 검증용)
+   */
+  @Transactional
+  public void rejectParticipation(Long togetherId, Long participantId, Long hostId) {
+    // 1. 참여 거절 처리 (권한 검증 포함)
+    togetherService.rejectParticipation(togetherId, participantId, hostId);
+
+    // 2. 추가 처리 (알림 등) - 향후 확장 가능
+    // notificationService.notifyParticipationRejected(together, participantId);
+  }
+
+
+  /**
+   * Together 삭제와 함께 관련 채팅방도 삭제
+   * - Together 삭제
+   * - 관련 채팅방 삭제
+   * - 관련 이미지 삭제 등
+   *
+   * @param togetherId Together ID
+   * @param requesterId 요청자 ID (권한 검증용)
+   */
+  @Transactional
+  public void deleteTogetherWithRelatedData(Long togetherId, Long requesterId) {
+    // 1. Together 삭제 (권한 검증 및 관련 데이터 삭제 포함)
+    // TogetherService.delete()에서 이미 채팅방, 참여자, 관심 등록 모두 삭제 처리
+    togetherService.delete(togetherId, requesterId);
+
+    // 2. 추가 정리 작업 (이미지 등) - 향후 확장 가능
+    // imageService.deleteTogetherImages(togetherId);
+  }
+}

--- a/src/main/java/com/culturemate/culturemate_api/init/AdminInitializer.java
+++ b/src/main/java/com/culturemate/culturemate_api/init/AdminInitializer.java
@@ -4,7 +4,7 @@ import com.culturemate.culturemate_api.domain.member.Member;
 import com.culturemate.culturemate_api.domain.member.Role;
 import com.culturemate.culturemate_api.dto.MemberDto;
 import com.culturemate.culturemate_api.repository.MemberRepository;
-import com.culturemate.culturemate_api.service.AuthService;
+import com.culturemate.culturemate_api.service.MemberService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,12 +17,12 @@ import java.util.Map;
 @Component
 public class AdminInitializer {
 
-  private final AuthService authService;
+  private final MemberService memberService;
   private final MemberRepository memberRepository;
 
   @Autowired
-  public AdminInitializer(AuthService authService, MemberRepository memberRepository) {
-    this.authService = authService;
+  public AdminInitializer(MemberService memberService, MemberRepository memberRepository) {
+    this.memberService = memberService;
     this.memberRepository = memberRepository;
   }
 
@@ -61,9 +61,8 @@ public class AdminInitializer {
         
         System.out.println("Register 생성 완료: " + loginId);
         
-        Member newAdmin = authService.register(registerDto);
-        // TODO: 권한 설정을 위한 별도 메서드 필요 또는 MemberService 사용
-        // memberService.updateRole(newAdmin.getId(), Role.ADMIN);
+        Member newAdmin = memberService.register(registerDto);
+        memberService.updateRole(newAdmin.getId(), Role.ADMIN);
         System.out.println("관리자 계정 생성 및 권한 설정 완료: " + loginId);
       }
       

--- a/src/main/java/com/culturemate/culturemate_api/init/AdminInitializer.java
+++ b/src/main/java/com/culturemate/culturemate_api/init/AdminInitializer.java
@@ -4,7 +4,7 @@ import com.culturemate.culturemate_api.domain.member.Member;
 import com.culturemate.culturemate_api.domain.member.Role;
 import com.culturemate.culturemate_api.dto.MemberDto;
 import com.culturemate.culturemate_api.repository.MemberRepository;
-import com.culturemate.culturemate_api.service.MemberService;
+import com.culturemate.culturemate_api.service.AuthService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,12 +17,12 @@ import java.util.Map;
 @Component
 public class AdminInitializer {
 
-  private final MemberService memberService;
+  private final AuthService authService;
   private final MemberRepository memberRepository;
 
   @Autowired
-  public AdminInitializer(MemberService memberService, MemberRepository memberRepository) {
-    this.memberService = memberService;
+  public AdminInitializer(AuthService authService, MemberRepository memberRepository) {
+    this.authService = authService;
     this.memberRepository = memberRepository;
   }
 
@@ -61,8 +61,9 @@ public class AdminInitializer {
         
         System.out.println("Register 생성 완료: " + loginId);
         
-        Member newAdmin = memberService.create(registerDto);
-        memberService.updateRole(newAdmin.getId(), Role.ADMIN);
+        Member newAdmin = authService.register(registerDto);
+        // TODO: 권한 설정을 위한 별도 메서드 필요 또는 MemberService 사용
+        // memberService.updateRole(newAdmin.getId(), Role.ADMIN);
         System.out.println("관리자 계정 생성 및 권한 설정 완료: " + loginId);
       }
       

--- a/src/main/java/com/culturemate/culturemate_api/init/MemberInitializer.java
+++ b/src/main/java/com/culturemate/culturemate_api/init/MemberInitializer.java
@@ -4,7 +4,7 @@ import com.culturemate.culturemate_api.domain.member.Member;
 import com.culturemate.culturemate_api.domain.member.Role;
 import com.culturemate.culturemate_api.dto.MemberDto;
 import com.culturemate.culturemate_api.repository.MemberRepository;
-import com.culturemate.culturemate_api.service.MemberService;
+import com.culturemate.culturemate_api.service.AuthService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,12 +17,12 @@ import java.util.Map;
 @Component
 public class MemberInitializer {
 
-  private final MemberService memberService;
+  private final AuthService authService;
   private final MemberRepository memberRepository;
 
   @Autowired
-  public MemberInitializer(MemberService memberService, MemberRepository memberRepository) {
-    this.memberService = memberService;
+  public MemberInitializer(AuthService authService, MemberRepository memberRepository) {
+    this.authService = authService;
     this.memberRepository = memberRepository;
   }
 
@@ -46,7 +46,7 @@ public class MemberInitializer {
             .email(loginId + "@culturemate.com")
             .build();
         
-        Member newMember = memberService.create(registerDto);
+        Member newMember = authService.register(registerDto);
         System.out.println("계정 생성 완료: " + loginId);
       }
       

--- a/src/main/java/com/culturemate/culturemate_api/init/MemberInitializer.java
+++ b/src/main/java/com/culturemate/culturemate_api/init/MemberInitializer.java
@@ -4,7 +4,7 @@ import com.culturemate.culturemate_api.domain.member.Member;
 import com.culturemate.culturemate_api.domain.member.Role;
 import com.culturemate.culturemate_api.dto.MemberDto;
 import com.culturemate.culturemate_api.repository.MemberRepository;
-import com.culturemate.culturemate_api.service.AuthService;
+import com.culturemate.culturemate_api.service.MemberService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,12 +17,12 @@ import java.util.Map;
 @Component
 public class MemberInitializer {
 
-  private final AuthService authService;
+  private final MemberService memberService;
   private final MemberRepository memberRepository;
 
   @Autowired
-  public MemberInitializer(AuthService authService, MemberRepository memberRepository) {
-    this.authService = authService;
+  public MemberInitializer(MemberService memberService, MemberRepository memberRepository) {
+    this.memberService = memberService;
     this.memberRepository = memberRepository;
   }
 
@@ -46,7 +46,7 @@ public class MemberInitializer {
             .email(loginId + "@culturemate.com")
             .build();
         
-        Member newMember = authService.register(registerDto);
+        Member newMember = memberService.register(registerDto);
         System.out.println("계정 생성 완료: " + loginId);
       }
       

--- a/src/main/java/com/culturemate/culturemate_api/repository/InquiryRepository.java
+++ b/src/main/java/com/culturemate/culturemate_api/repository/InquiryRepository.java
@@ -9,18 +9,16 @@ import java.util.List;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
     
-    // fetch join을 사용해 Member 정보도 함께 조회하도록 변경
+    // fetch join을 사용해 Member 정보도 함께 조회 (이미지는 ImageService에서 별도 조회)
     @Query("SELECT i FROM Inquiry i " +
       "JOIN FETCH i.author " +
-      "LEFT JOIN FETCH i.images " +
       "WHERE i.author = :author " +
       "ORDER BY i.createdAt DESC")
-    List<Inquiry> findByAuthorWithImages(Member author);
+    List<Inquiry> findByAuthor(Member author);
 
-    // 관리자용 전체 조회 기능에도 fetch join 추가
+    // 관리자용 전체 조회 (이미지는 ImageService에서 별도 조회)
     @Query("SELECT i FROM Inquiry i " +
       "JOIN FETCH i.author " +
-      "LEFT JOIN FETCH i.images " +
       "ORDER BY i.createdAt DESC")
-    List<Inquiry> findAllWithAuthorAndImages();
+    List<Inquiry> findAllWithAuthor();
 }

--- a/src/main/java/com/culturemate/culturemate_api/repository/MemberDetailRepository.java
+++ b/src/main/java/com/culturemate/culturemate_api/repository/MemberDetailRepository.java
@@ -9,6 +9,9 @@ import java.util.Optional;
 
 public interface MemberDetailRepository extends JpaRepository<MemberDetail, Long> {
 
+  // 이메일 중복 검증
+  boolean existsByEmail(String email);
+
   // N+1 문제 해결: 관심 이벤트 타입과 태그를 한 번에 조회
   @Query("""
       SELECT DISTINCT md

--- a/src/main/java/com/culturemate/culturemate_api/service/AuthService.java
+++ b/src/main/java/com/culturemate/culturemate_api/service/AuthService.java
@@ -1,30 +1,38 @@
 package com.culturemate.culturemate_api.service;
 
+import com.culturemate.culturemate_api.domain.member.Member;
+import com.culturemate.culturemate_api.domain.member.Role;
 import com.culturemate.culturemate_api.dto.AuthenticatedUser;
+import com.culturemate.culturemate_api.dto.MemberDto;
 import com.culturemate.culturemate_api.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
 @Service
-public class LoginService implements UserDetailsService {
+@Transactional(readOnly = true)
+public class AuthService implements UserDetailsService {
 
   private final MemberRepository memberRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final MemberDetailService memberDetailService;
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 //    DB에서 username을 가진 유저를 찾아와서
 //    Member 엔티티 기반으로 AuthenticatedUser 생성
 
-    System.out.println("=== [" + java.time.LocalDateTime.now() + "] LoginService.loadUserByUsername called ===");
+    System.out.println("=== [" + java.time.LocalDateTime.now() + "] AuthService.loadUserByUsername called ===");
     System.out.println("  - Username: " + username);
 
     try {
@@ -56,6 +64,51 @@ public class LoginService implements UserDetailsService {
       System.err.println("  - ERROR in loadUserByUsername: " + e.getMessage());
       e.printStackTrace();
       throw e;
+    }
+  }
+
+  // 회원 가입
+  @Transactional
+  public Member register(MemberDto.Register registerDto) {
+    if (memberRepository.existsByLoginId(registerDto.getLoginId())) {
+      throw new IllegalArgumentException("이미 사용 중인 로그인 아이디입니다.");
+    }
+
+    var hash = passwordEncoder.encode(registerDto.getPassword());
+
+    Member member = Member.builder()
+      .loginId(registerDto.getLoginId())
+      .password(hash)
+      .build();
+
+    Member savedMember = memberRepository.save(member);
+    memberDetailService.create(savedMember, MemberDto.DetailRequest.from(registerDto));
+
+    return savedMember;
+  }
+
+  // 권한 검증
+  public void validateProfileAccess(Long profileMemberId, Long requesterId) {
+    Member requester = memberRepository.findById(requesterId)
+        .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+    // ADMIN은 모든 프로필 수정/삭제 가능
+    if (requester.getRole() == Role.ADMIN) {
+      return;
+    }
+
+    // 일반 사용자는 본인 프로필만
+    if (!profileMemberId.equals(requesterId)) {
+      throw new IllegalArgumentException("본인의 프로필만 수정/삭제할 수 있습니다.");
+    }
+  }
+
+  public void validateAdminAccess(Long requesterId) {
+    Member requester = memberRepository.findById(requesterId)
+        .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+    if (requester.getRole() != Role.ADMIN) {
+      throw new IllegalArgumentException("관리자 권한이 필요합니다.");
     }
   }
 

--- a/src/main/java/com/culturemate/culturemate_api/service/AuthService.java
+++ b/src/main/java/com/culturemate/culturemate_api/service/AuthService.java
@@ -3,10 +3,8 @@ package com.culturemate.culturemate_api.service;
 import com.culturemate.culturemate_api.domain.member.Member;
 import com.culturemate.culturemate_api.domain.member.Role;
 import com.culturemate.culturemate_api.dto.AuthenticatedUser;
-import com.culturemate.culturemate_api.dto.MemberDto;
 import com.culturemate.culturemate_api.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -24,8 +22,6 @@ import java.util.List;
 public class AuthService implements UserDetailsService {
 
   private final MemberRepository memberRepository;
-  private final PasswordEncoder passwordEncoder;
-  private final MemberDetailService memberDetailService;
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
@@ -67,25 +63,6 @@ public class AuthService implements UserDetailsService {
     }
   }
 
-  // 회원 가입
-  @Transactional
-  public Member register(MemberDto.Register registerDto) {
-    if (memberRepository.existsByLoginId(registerDto.getLoginId())) {
-      throw new IllegalArgumentException("이미 사용 중인 로그인 아이디입니다.");
-    }
-
-    var hash = passwordEncoder.encode(registerDto.getPassword());
-
-    Member member = Member.builder()
-      .loginId(registerDto.getLoginId())
-      .password(hash)
-      .build();
-
-    Member savedMember = memberRepository.save(member);
-    memberDetailService.create(savedMember, MemberDto.DetailRequest.from(registerDto));
-
-    return savedMember;
-  }
 
   // 권한 검증
   public void validateProfileAccess(Long profileMemberId, Long requesterId) {

--- a/src/main/java/com/culturemate/culturemate_api/service/MemberDetailService.java
+++ b/src/main/java/com/culturemate/culturemate_api/service/MemberDetailService.java
@@ -23,6 +23,11 @@ public class MemberDetailService {
   private final ImageService imageService;
   private final TagRepository tagRepository;
 
+  // 이메일 중복 검증
+  public boolean existsByEmail(String email) {
+    return memberDetailRepository.existsByEmail(email);
+  }
+
   // 관심사와 함께 회원 상세 조회 (N+1 방지)
   public MemberDetail findByMemberId(Long memberId) {
     return memberDetailRepository.findByIdWithAllInterests(memberId)

--- a/src/main/java/com/culturemate/culturemate_api/service/MemberService.java
+++ b/src/main/java/com/culturemate/culturemate_api/service/MemberService.java
@@ -24,26 +24,6 @@ public class MemberService {
   private final MemberDetailService memberDetailService;
 
 
-  // 회원 가입
-  @Transactional
-  public Member create(MemberDto.Register registerDto) {
-    if (memberRepository.existsByLoginId(registerDto.getLoginId())) {
-      throw new IllegalArgumentException("이미 사용 중인 로그인 아이디입니다.");
-    }
-
-    var hash = passwordEncoder.encode(registerDto.getPassword());
-
-    Member member = Member.builder()
-      .loginId(registerDto.getLoginId())
-      .password(hash)
-      .build();
-
-    Member savedMember = memberRepository.save(member);
-    memberDetailService.create(savedMember, MemberDto.DetailRequest.from(registerDto));
-
-    return savedMember;
-  }
-
   // 회원 삭제
   @Transactional
   public void delete(Long memberId) {

--- a/src/main/java/com/culturemate/culturemate_api/service/MemberService.java
+++ b/src/main/java/com/culturemate/culturemate_api/service/MemberService.java
@@ -30,6 +30,13 @@ public class MemberService {
       throw new IllegalArgumentException("이미 사용 중인 로그인 아이디입니다.");
     }
 
+    // 이메일이 있는 경우 중복 검증
+    if (registerDto.getEmail() != null && !registerDto.getEmail().trim().isEmpty()) {
+      if (memberDetailService.existsByEmail(registerDto.getEmail())) {
+        throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+      }
+    }
+
     var hash = passwordEncoder.encode(registerDto.getPassword());
 
     Member member = Member.builder()
@@ -64,6 +71,11 @@ public class MemberService {
   public Member findByLoginId(String loginId) {
     return memberRepository.findByLoginId(loginId)
       .orElseThrow(() -> new IllegalArgumentException("해당 아이디의 회원이 없습니다."));
+  }
+
+  // 로그인 아이디 중복 확인
+  public boolean existsByLoginId(String loginId) {
+    return memberRepository.existsByLoginId(loginId);
   }
 
   // 상태별 회원 조회

--- a/src/main/java/com/culturemate/culturemate_api/service/MemberService.java
+++ b/src/main/java/com/culturemate/culturemate_api/service/MemberService.java
@@ -23,6 +23,25 @@ public class MemberService {
   private final PasswordEncoder passwordEncoder;
   private final MemberDetailService memberDetailService;
 
+  // 회원 가입
+  @Transactional
+  public Member register(MemberDto.Register registerDto) {
+    if (memberRepository.existsByLoginId(registerDto.getLoginId())) {
+      throw new IllegalArgumentException("이미 사용 중인 로그인 아이디입니다.");
+    }
+
+    var hash = passwordEncoder.encode(registerDto.getPassword());
+
+    Member member = Member.builder()
+      .loginId(registerDto.getLoginId())
+      .password(hash)
+      .build();
+
+    Member savedMember = memberRepository.save(member);
+    memberDetailService.create(savedMember, MemberDto.DetailRequest.from(registerDto));
+
+    return savedMember;
+  }
 
   // 회원 삭제
   @Transactional

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,6 +22,11 @@ custom:
     upload:
       default: src/test/resources/static/images
 
+# JWT 설정 (테스트용)
+jwt:
+  secret: ${JWT_SECRET}
+  expiration: ${JWT_EXPIRATION}
+
 # CORS 설정 (테스트용)
 cors:
   allowed-origins: http://localhost:3000


### PR DESCRIPTION
##  📋 개요

  회원가입 프로세스의 보안을 강화하고, Together 도메인에 Facade 패턴을 적용하여 아키텍처를 개선했습니다. 또한 순환
  참조 문제를 해결하고 문의 시스템의 이미지 관리 패턴을 통일했습니다.

##  🎯 주요 변경사항

###  1. 🔐 회원가입 보안 강화 (c92962d)

  - 비밀번호 복잡성 검증 강화
    - 영문자, 숫자, 특수문자(!@#$%^&*()_+-=.,?) 각 1개 이상 필수 포함
    - 8자 이상 100자 이하 제한
    - 정규식 패턴: ^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=.,?])[a-zA-Z\\d!@#$%^&*()_+\\-=.,?]+$
  - 중복 확인 API 추가
    - GET /api/v1/auth/check-login-id - 아이디 중복 확인
    - GET /api/v1/auth/check-email - 이메일 중복 확인
    - 실시간 검증을 위한 별도 엔드포인트 제공

###  2. 🏗️ Together 도메인 Facade 패턴 적용 (b260b72)

  - TogetherFacade 클래스 신규 도입
    - 복잡한 비즈니스 로직을 단순화
    - 여러 서비스 간 조율 담당
    - 트랜잭션 경계 관리 개선
  - 인증/권한 로직 재구성
    - 호스트와 참여자 권한 검증 로직 통합
    - 일관된 권한 검증 패턴 적용

###  3. ♻️ 순환 참조 및 아키텍처 개선 (fc2e1ae)

  - AuthService 순환 참조 해결
    - register() 메서드를 MemberService로 이동
    - AuthService에서 MemberDetailService 의존성 제거
    - 단일 책임 원칙 적용 (AuthService: 인증, MemberService: 회원가입)
  - 문의 시스템 이미지 관리 패턴 통일
    - @OneToMany + @JoinColumn 제거로 DB 제약조건 오류 해결
    - Event, Board와 동일한 ImageService 패턴 적용
    - 일관된 이미지 관리 체계 구축

###  4. 🐛 멤버 관심사 관리 시스템 복원 (10643db)

  - 권한 검증 로직 수정
    - 멤버 관심사 관리 API 권한 검증 버그 수정
    - 관심사 CRUD 기능 정상 작동 복원

##  🔄 Breaking Changes

  - AuthApiController → AuthController로 클래스명 변경
  - LoginService → AuthService로 클래스명 변경
  - register() 메서드가 AuthService에서 MemberService로 이동

##  📝 주요 파일 변경

  - Controllers: AuthController 확장, TogetherController 개선
  - Services: AuthService/MemberService 책임 재정의, TogetherService 최적화
  - Facade: TogetherFacade 신규 추가 (118 lines)
  - DTOs: MemberDto 비밀번호 검증 강화, InquiryDto 구조 개선

##  ✅ 체크리스트

  - 코드 리뷰 완료
  - 기존 테스트 통과 확인
  - 순환 참조 해결 확인
  - API 문서 업데이트
  - 보안 검증 (비밀번호 복잡성, SQL Injection 방지)
